### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tinygo: ['0.19', '0.20']
+        tinygo: ['0.19.0', '0.20.0']
     name: TinyGo ${{ matrix.tinygo }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
"tinygo-version" requires a full version.

Thank you for the useful github-actions!