### PR TITLE
feat: option to skip binaryen install

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,3 +30,22 @@ jobs:
       - name: Test build
         run: ./test-build.sh
         shell: bash
+
+  no-binaryen:
+    name: No Binaryen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: setup-tinygo
+        uses: ./
+        with:
+          tinygo-version: '0.27.0'
+          install-binaryen: 'false'
+
+      - name: Binaryen not installed
+        run: ./test-binaryen.sh
+        shell: bash

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,9 @@ jobs:
 
   no-binaryen:
     name: No Binaryen
-    runs-on: ubuntu-latest
+    # using macos because ubuntu has binaryen pre-installed
+    # TO-DO: implement a stable testing method
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ steps:
       tinygo-version: '0.27.0'
       binaryen-version: '110'
 ```
+
+### Without Binaryen
+
+If you don't need Binaryen, you can omit the installation
+
+```yaml
+steps:
+  - uses: actions/checkout@v2
+  - uses: acifani/setup-tinygo@v1
+    with:
+      tinygo-version: '0.27.0'
+      install-binaryen: 'false'
+```

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   tinygo-version:
     description: 'The exact TinyGo version to download and use.'
     default: '0.25.0'
+  install-binaryen:
+    description: 'Whether you want to install Binaryen or not.'
+    default: 'true'
   binaryen-version:
     description: 'The exact Binaryen version to download and use.'
     default: '110'

--- a/dist/index.js
+++ b/dist/index.js
@@ -156,10 +156,16 @@ async function setup() {
     try {
         const tinyGoVersion = core.getInput('tinygo-version');
         core.info(`Setting up tinygo version ${tinyGoVersion}`);
-        const binaryenVersion = core.getInput('binaryen-version');
-        core.info(`Setting up binaryen version ${binaryenVersion}`);
         await (0, install_2.installTinyGo)(tinyGoVersion);
-        await (0, install_1.installBinaryen)(binaryenVersion);
+        const shouldInstallBinaryen = core.getInput('install-binaryen');
+        if (shouldInstallBinaryen === 'false') {
+            core.info('Skipping binaryen installation');
+        }
+        else {
+            const binaryenVersion = core.getInput('binaryen-version');
+            core.info(`Setting up binaryen version ${binaryenVersion}`);
+            await (0, install_1.installBinaryen)(binaryenVersion);
+        }
     }
     catch (error) {
         core.setFailed(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,16 @@ async function setup() {
   try {
     const tinyGoVersion = core.getInput('tinygo-version');
     core.info(`Setting up tinygo version ${tinyGoVersion}`);
-    const binaryenVersion = core.getInput('binaryen-version');
-    core.info(`Setting up binaryen version ${binaryenVersion}`);
-
     await installTinyGo(tinyGoVersion);
-    await installBinaryen(binaryenVersion);
+
+    const shouldInstallBinaryen = core.getInput('install-binaryen');
+    if (shouldInstallBinaryen === 'false') {
+      core.info('Skipping binaryen installation');
+    } else {
+      const binaryenVersion = core.getInput('binaryen-version');
+      core.info(`Setting up binaryen version ${binaryenVersion}`);
+      await installBinaryen(binaryenVersion);
+    }
   } catch (error: any) {
     core.setFailed(error.message);
   }

--- a/test-binaryen.sh
+++ b/test-binaryen.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Checks that Binaryen is not installed
+if [ -x "$(command -v wasm-opt)" ]; then
+    echo 'Error: Binaryen is installed.' >&2
+    exit 1
+fi


### PR DESCRIPTION
Add the input `install-binaryen` which can be set to `false` to skip the Binaryen install process.

Closes #5 